### PR TITLE
Don't exit 0

### DIFF
--- a/.profile.d/heroku-metrics-daemon.sh
+++ b/.profile.d/heroku-metrics-daemon.sh
@@ -1,32 +1,30 @@
 #!/bin/bash
 
 # don't do anything if we don't have a metrics url.
-if [ -z "$HEROKU_METRICS_URL" ]; then
-    exit 0
-fi
+if [[ -n "$HEROKU_METRICS_URL" ]]; then
+    export HEROKU_METRICS_PROM_ENDPOINT=${HEROKU_METRICS_PROM_ENDPOINT:-/metrics}
+    export HEROKU_METRICS_PROM_PORT=$((PORT + 1))
+    export HEROKU_PROM_METRICS_ENDPOINT=${HEROKU_METRICS_PROM_ENDPOINT}
+    export HEROKU_PROM_METRICS_PORT=${HEROKU_METRICS_PROM_PORT}
 
-export HEROKU_METRICS_PROM_ENDPOINT=${HEROKU_METRICS_PROM_ENDPOINT:-/metrics}
-export HEROKU_METRICS_PROM_PORT=$(expr $PORT + 1)
-export HEROKU_PROM_METRICS_ENDPOINT=${HEROKU_METRICS_PROM_ENDPOINT}
-export HEROKU_PROM_METRICS_PORT=${HEROKU_METRICS_PROM_PORT}
+    if [[ -f pom.xml ]]; then
+        export JAVA_TOOL_OPTIONS="-javaagent:bin/heroku-metrics-agent.jar ${JAVA_TOOL_OPTIONS}"
+        AGENTMON_FLAGS="-prom-url http://localhost:${HEROKU_METRICS_PROM_PORT}${HEROKU_METRICS_PROM_ENDPOINT}"
+    else
+        AGENTMON_FLAGS="-statsd-addr :${PORT}"
+    fi
 
-if [ -f pom.xml ]; then
-    export JAVA_TOOL_OPTIONS="-javaagent:bin/heroku-metrics-agent.jar ${JAVA_TOOL_OPTIONS}"
-    AGENTMON_FLAGS="-prom-url http://localhost:${HEROKU_METRICS_PROM_PORT}${HEROKU_METRICS_PROM_ENDPOINT}"
-else
-    AGENTMON_FLAGS="-statsd-addr :${PORT}"
-fi
+    if [[ "${AGENTMON_DEBUG}" = "true" ]]; then
+        AGENTMON_FLAGS="${AGENTMON_FLAGS} -debug"
+    fi
 
-if [ "${AGENTMON_DEBUG}" = "true" ]; then
-    AGENTMON_FLAGS="${AGENTMON_FLAGS} -debug"
-fi
-
-if [ -x "./bin/agentmon" ]; then
-    (while true; do
-        ./bin/agentmon ${AGENTMON_FLAGS} ${HEROKU_METRICS_URL}
-        echo "agentmon completed with status=${?}. Restarting"
-        sleep 1
-    done) &
-else
-    echo "No agentmon executable found. Not starting."
+    if [[ -x "./bin/agentmon" ]]; then
+        (while true; do
+            ./bin/agentmon "${AGENTMON_FLAGS}" "${HEROKU_METRICS_URL}"
+            echo "agentmon completed with status=${?}. Restarting"
+            sleep 1
+        done) &
+    else
+        echo "No agentmon executable found. Not starting."
+    fi
 fi


### PR DESCRIPTION
Also ran it through shellcheck and fixed the issues reported.

w/o this the buildpack w/o the env var set will cause dynos to crash

```
2017-03-28T19:07:46.436102+00:00 heroku[web.1]: State changed from starting to crashed
2017-03-28T19:07:46.415263+00:00 heroku[web.1]: Process exited with status 0
```