### PR TITLE
Support all JVM apps

### DIFF
--- a/.profile.d/heroku-metrics-daemon.sh
+++ b/.profile.d/heroku-metrics-daemon.sh
@@ -32,7 +32,7 @@ echo "agentmon setup took ${ELAPSEDTIME} seconds"
 
 AGENTMON_FLAGS=()
 
-if [ -f pom.xml ]; then
+if [ -f .jdk/bin/java ]; then
     export JAVA_TOOL_OPTIONS="-javaagent:bin/heroku-metrics-agent.jar ${JAVA_TOOL_OPTIONS}"
     AGENTMON_FLAGS+=("-prom-url=http://localhost:${HEROKU_METRICS_PROM_PORT}${HEROKU_METRICS_PROM_ENDPOINT}")
 else


### PR DESCRIPTION
This is a better, and more general detection of a Java app.

The `pom.xml` only exists for apps using the Java buildpack. But we also want to support:

* WAR files
* Executable JAR files
* Gradle apps
* Clojure, Scala, JRuby apps

All of these will have the JDK installed by the [heroku/jvm buildpack](https://github.com/heroku/heroku-buildpack-jvm-common), which creates the `.jdk/bin/java` file in the slug.