### PR TITLE
Added special case to set bootclasspath for Scala apps

### DIFF
--- a/.profile.d/heroku-metrics-daemon.sh
+++ b/.profile.d/heroku-metrics-daemon.sh
@@ -32,8 +32,12 @@ echo "agentmon setup took ${ELAPSEDTIME} seconds"
 
 AGENTMON_FLAGS=()
 
-if [ -f pom.xml ]; then
+if [ -f pom.xml ] || [ -f build.gradle ]; then
     export JAVA_TOOL_OPTIONS="-javaagent:bin/heroku-metrics-agent.jar ${JAVA_TOOL_OPTIONS}"
+    AGENTMON_FLAGS+=("-prom-url=http://localhost:${HEROKU_METRICS_PROM_PORT}${HEROKU_METRICS_PROM_ENDPOINT}")
+elif [ -f build.sbt ]; then
+    unzip -qq bin/heroku-metrics-agent.jar 'javax/*' -d bin/ext/
+    export JAVA_OPTS="-javaagent:bin/heroku-metrics-agent.jar=cp=/app/bin/ext/ -Xbootclasspath/a:bin/heroku-metrics-agent.jar ${JAVA_OPTS}"
     AGENTMON_FLAGS+=("-prom-url=http://localhost:${HEROKU_METRICS_PROM_PORT}${HEROKU_METRICS_PROM_ENDPOINT}")
 else
     AGENTMON_FLAGS+=("-statsd-addr=:${PORT}")

--- a/bin/compile
+++ b/bin/compile
@@ -16,8 +16,8 @@ arrow "Setting up .profile.d to automatically run agentmon..."
 mkdir -p "${BUILD_DIR}/.profile.d"
 cp .profile.d/heroku-metrics-daemon.sh "${BUILD_DIR}/.profile.d"
 
-if [[ -f "${BUILD_DIR}/pom.xml" ]]; then
+if [[ -f "${BUILD_DIR}/pom.xml" ]] || [ -f build.gradle ] || [ -f build.sbt ]; then
     arrow "Installing Java metrics agent"
     mkdir -p "${BUILD_DIR}/bin/"
-    curl --retry 3 -s -o "${BUILD_DIR}/bin/heroku-metrics-agent.jar" -L https://lang-jvm.s3.amazonaws.com/heroku-metrics-agent.jar
+    curl --retry 3 -s -o "${BUILD_DIR}/bin/heroku-metrics-agent.jar" -L https://lang-jvm.s3.amazonaws.com/heroku-metrics-agent-1.9.jar
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -16,7 +16,7 @@ arrow "Setting up .profile.d to automatically run agentmon..."
 mkdir -p "${BUILD_DIR}/.profile.d"
 cp .profile.d/heroku-metrics-daemon.sh "${BUILD_DIR}/.profile.d"
 
-if [[ -f "${BUILD_DIR}/pom.xml" ]] || [ -f build.gradle ] || [ -f build.sbt ]; then
+if [[ -f "${BUILD_DIR}/pom.xml" ]] || [[ -f "${BUILD_DIR}/build.gradle" ]] || [[ -f "${BUILD_DIR}/build.sbt" ]]; then
     arrow "Installing Java metrics agent"
     mkdir -p "${BUILD_DIR}/bin/"
     curl --retry 3 -s -o "${BUILD_DIR}/bin/heroku-metrics-agent.jar" -L https://lang-jvm.s3.amazonaws.com/heroku-metrics-agent-1.9.jar


### PR DESCRIPTION
This pins the Java agent to specific version, which makes it easier for me to stage and test changes. I may submit a second PR to return to the default agent URL after I promote 1.9.