### PR TITLE
Added support for jdk dir detection

### DIFF
--- a/.profile.d/heroku-metrics-daemon.sh
+++ b/.profile.d/heroku-metrics-daemon.sh
@@ -32,7 +32,7 @@ echo "agentmon setup took ${ELAPSEDTIME} seconds"
 
 AGENTMON_FLAGS=()
 
-if [ -f pom.xml ] || [ -f build.gradle ]; then
+if [ -f pom.xml ] || [ -f build.gradle ] || [ -d .jdk ]; then
     export JAVA_TOOL_OPTIONS="-javaagent:bin/heroku-metrics-agent.jar ${JAVA_TOOL_OPTIONS}"
     AGENTMON_FLAGS+=("-prom-url=http://localhost:${HEROKU_METRICS_PROM_PORT}${HEROKU_METRICS_PROM_ENDPOINT}")
 elif [ -f build.sbt ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -16,7 +16,7 @@ arrow "Setting up .profile.d to automatically run agentmon..."
 mkdir -p "${BUILD_DIR}/.profile.d"
 cp .profile.d/heroku-metrics-daemon.sh "${BUILD_DIR}/.profile.d"
 
-if [[ -f "${BUILD_DIR}/pom.xml" ]] || [[ -f "${BUILD_DIR}/build.gradle" ]] || [[ -f "${BUILD_DIR}/build.sbt" ]]; then
+if [[ -f "${BUILD_DIR}/pom.xml" ]] || [[ -f "${BUILD_DIR}/build.gradle" ]] || [[ -f "${BUILD_DIR}/build.sbt" ]] || [[ -d "${BUILD_DIR}/.jdk" ]]; then
     arrow "Installing Java metrics agent"
     mkdir -p "${BUILD_DIR}/bin/"
     curl --retry 3 -s -o "${BUILD_DIR}/bin/heroku-metrics-agent.jar" -L https://lang-jvm.s3.amazonaws.com/heroku-metrics-agent-1.9.jar


### PR DESCRIPTION
This requires that the metrics buildpack be set *after* the `heroku/jvm` buildpack.