### PR TITLE
agentmon setup now grabs from s3 instead of github releases

### DIFF
--- a/.profile.d/heroku-metrics-daemon.sh
+++ b/.profile.d/heroku-metrics-daemon.sh
@@ -10,7 +10,8 @@ export HEROKU_METRICS_PROM_PORT=$((PORT + 1))
 
 STARTTIME=$(date +%s)
 BUILD_DIR=/tmp
-DOWNLOAD_URL=$(curl --retry 3 -s https://api.github.com/repos/heroku/agentmon/releases/latest | grep "browser_download_url" | awk -F': ' '{print $2}' | sed -e 's/"//g')
+
+DOWNLOAD_URL=$(curl --retry 3 -s https://agentmon-releases.s3.amazonaws.com/latest)
 if [ -z "${DOWNLOAD_URL}" ]; then
     echo "!!!!! Failed to find latest agentmon. Please report this as a bug. Metrics collection will be disabled this run."
     return 0


### PR DESCRIPTION
This relates to heroku/agentmon#12
This relates to #6 

Fetch agentmon from s3 instead of github releases. This eliminates us from using grep, awk and sed to parse json.