### PR TITLE
Updated to java metrics agent 2.0

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -19,5 +19,5 @@ cp .profile.d/heroku-metrics-daemon.sh "${BUILD_DIR}/.profile.d"
 if [[ -f "${BUILD_DIR}/pom.xml" ]] || [[ -f "${BUILD_DIR}/build.gradle" ]] || [[ -f "${BUILD_DIR}/build.sbt" ]] || [[ -d "${BUILD_DIR}/.jdk" ]]; then
     arrow "Installing Java metrics agent"
     mkdir -p "${BUILD_DIR}/bin/"
-    curl --retry 3 -s -o "${BUILD_DIR}/bin/heroku-metrics-agent.jar" -L https://lang-jvm.s3.amazonaws.com/heroku-metrics-agent-1.9.jar
+    curl --retry 3 -s -o "${BUILD_DIR}/bin/heroku-metrics-agent.jar" -L https://lang-jvm.s3.amazonaws.com/heroku-metrics-agent-2.0.jar
 fi


### PR DESCRIPTION
This version of the Java agent adds six new metrics:

```
jvm_buffer_pool_bytes_used{name="direct"} 2000000
jvm_buffer_pool_bytes_capacity{name="direct"} 200000
jvm_buffer_pool_count{name="direct"} 20
jvm_buffer_pool_bytes_used{name="mapped"} 1000000
jvm_buffer_pool_bytes_capacity{name="mapped"} 100000
jvm_buffer_pool_count{name="mapped"} 10
```

The Buffer Pools are derived from [BufferPoolMXBean](https://docs.oracle.com/javase/8/docs/api/java/lang/management/BufferPoolMXBean.html) and represent non-heap memory created with [ByteBuffer.allocateDirect](https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html#allocateDirect-int-) and [FileChannel.map](https://docs.oracle.com/javase/8/docs/api/java/nio/channels/FileChannel.html#map-java.nio.channels.FileChannel.MapMode-long-long-).

Ideally, the `used` metrics will be stacked with the non-heap graph.