### PR TITLE
Added detection for webapp-runer to support heroku-cli-deploy

### DIFF
--- a/.profile.d/heroku-metrics-daemon.sh
+++ b/.profile.d/heroku-metrics-daemon.sh
@@ -33,18 +33,18 @@ echo "agentmon setup took ${ELAPSEDTIME} seconds"
 
 AGENTMON_FLAGS=()
 
-
+# heroku-metrics-agent.jar is added in bin/compile
 if [[ -f bin/heroku-metrics-agent.jar ]]; then
-    if [[ -f build.sbt ]] ||
-       [[ -d target/resolution-cache ]]; then
+    if [[ -f build.sbt ]] || # Scala
+       [[ -d target/resolution-cache ]]; then # Scala (sbt-heroku)
         unzip -qq bin/heroku-metrics-agent.jar 'javax/*' -d bin/ext/
         export JAVA_OPTS="-javaagent:bin/heroku-metrics-agent.jar=cp=/app/bin/ext/ -Xbootclasspath/a:bin/heroku-metrics-agent.jar ${JAVA_OPTS}"
         AGENTMON_FLAGS+=("-prom-url=http://localhost:${HEROKU_METRICS_PROM_PORT}${HEROKU_METRICS_PROM_ENDPOINT}")
-    elif [[ -f pom.xml ]] ||
-         [[ -f build.gradle ]] ||
-         [[ -f project.clj ]] ||
-         [[ -f target/dependency/webapp-runner.jar ]] ||
-         [[ -d .jdk ]]; then
+    elif [[ -f pom.xml ]] || # Maven
+         [[ -f build.gradle ]] || # Gradle
+         [[ -f project.clj ]] || # Clojure
+         [[ -f target/dependency/webapp-runner.jar ]] || # Tomcat
+         [[ -d .jdk ]]; then # heroku/jvm
         export JAVA_TOOL_OPTIONS="-javaagent:bin/heroku-metrics-agent.jar ${JAVA_TOOL_OPTIONS}"
         AGENTMON_FLAGS+=("-prom-url=http://localhost:${HEROKU_METRICS_PROM_PORT}${HEROKU_METRICS_PROM_ENDPOINT}")
     fi

--- a/.profile.d/heroku-metrics-daemon.sh
+++ b/.profile.d/heroku-metrics-daemon.sh
@@ -33,13 +33,21 @@ echo "agentmon setup took ${ELAPSEDTIME} seconds"
 
 AGENTMON_FLAGS=()
 
-if [[ -f build.sbt ]] || [[ -d target/resolution-cache ]]; then
-    unzip -qq bin/heroku-metrics-agent.jar 'javax/*' -d bin/ext/
-    export JAVA_OPTS="-javaagent:bin/heroku-metrics-agent.jar=cp=/app/bin/ext/ -Xbootclasspath/a:bin/heroku-metrics-agent.jar ${JAVA_OPTS}"
-    AGENTMON_FLAGS+=("-prom-url=http://localhost:${HEROKU_METRICS_PROM_PORT}${HEROKU_METRICS_PROM_ENDPOINT}")
-elif [[ -f pom.xml ]] || [[ -f build.gradle ]] || [[ -f project.clj ]] || [[ -d .jdk ]]; then
-    export JAVA_TOOL_OPTIONS="-javaagent:bin/heroku-metrics-agent.jar ${JAVA_TOOL_OPTIONS}"
-    AGENTMON_FLAGS+=("-prom-url=http://localhost:${HEROKU_METRICS_PROM_PORT}${HEROKU_METRICS_PROM_ENDPOINT}")
+
+if [[ -f bin/heroku-metrics-agent.jar ]]; then
+    if [[ -f build.sbt ]] ||
+       [[ -d target/resolution-cache ]]; then
+        unzip -qq bin/heroku-metrics-agent.jar 'javax/*' -d bin/ext/
+        export JAVA_OPTS="-javaagent:bin/heroku-metrics-agent.jar=cp=/app/bin/ext/ -Xbootclasspath/a:bin/heroku-metrics-agent.jar ${JAVA_OPTS}"
+        AGENTMON_FLAGS+=("-prom-url=http://localhost:${HEROKU_METRICS_PROM_PORT}${HEROKU_METRICS_PROM_ENDPOINT}")
+    elif [[ -f pom.xml ]] ||
+         [[ -f build.gradle ]] ||
+         [[ -f project.clj ]] ||
+         [[ -f target/dependency/webapp-runner.jar ]] ||
+         [[ -d .jdk ]]; then
+        export JAVA_TOOL_OPTIONS="-javaagent:bin/heroku-metrics-agent.jar ${JAVA_TOOL_OPTIONS}"
+        AGENTMON_FLAGS+=("-prom-url=http://localhost:${HEROKU_METRICS_PROM_PORT}${HEROKU_METRICS_PROM_ENDPOINT}")
+    fi
 else
     AGENTMON_FLAGS+=("-statsd-addr=:${PORT}")
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -21,6 +21,7 @@ if [[ -f "${BUILD_DIR}/pom.xml" ]] ||
    [[ -f "${BUILD_DIR}/build.sbt" ]] ||
    [[ -d "${BUILD_DIR}/target/resolution-cache" ]] ||
    [[ -f "${BUILD_DIR}/project.clj" ]] ||
+   [[ -f "${BUILD_DIR}/target/dependency/webapp-runner.jar" ]] ||
    [[ -d "${BUILD_DIR}/.jdk" ]]; then
     arrow "Installing Java metrics agent"
     mkdir -p "${BUILD_DIR}/bin/"

--- a/bin/compile
+++ b/bin/compile
@@ -16,13 +16,13 @@ arrow "Setting up .profile.d to automatically run agentmon..."
 mkdir -p "${BUILD_DIR}/.profile.d"
 cp .profile.d/heroku-metrics-daemon.sh "${BUILD_DIR}/.profile.d"
 
-if [[ -f "${BUILD_DIR}/pom.xml" ]] ||
-   [[ -f "${BUILD_DIR}/build.gradle" ]] ||
-   [[ -f "${BUILD_DIR}/build.sbt" ]] ||
-   [[ -d "${BUILD_DIR}/target/resolution-cache" ]] ||
-   [[ -f "${BUILD_DIR}/project.clj" ]] ||
-   [[ -f "${BUILD_DIR}/target/dependency/webapp-runner.jar" ]] ||
-   [[ -d "${BUILD_DIR}/.jdk" ]]; then
+if [[ -f "${BUILD_DIR}/pom.xml" ]] || # Maven
+   [[ -f "${BUILD_DIR}/build.gradle" ]] || # Gradle
+   [[ -f "${BUILD_DIR}/build.sbt" ]] || # Scala
+   [[ -d "${BUILD_DIR}/target/resolution-cache" ]] || # Scala (sbt-heroku)
+   [[ -f "${BUILD_DIR}/project.clj" ]] || # Clojure
+   [[ -f "${BUILD_DIR}/target/dependency/webapp-runner.jar" ]] || # Tomcat
+   [[ -d "${BUILD_DIR}/.jdk" ]]; then # heroku/jvm
     arrow "Installing Java metrics agent"
     mkdir -p "${BUILD_DIR}/bin/"
     curl --retry 3 -s -o "${BUILD_DIR}/bin/heroku-metrics-agent.jar" -L https://lang-jvm.s3.amazonaws.com/heroku-metrics-agent-2.0.jar


### PR DESCRIPTION
This fixed a problem where the Heroku Deploy CLI plugin required the buildpacks to be in the reverse order (`heroku/jvm`,`heroku/metrics`). The resulting bad behavior was:

* The `heroku-metrics-agent.jar` was not copied into the slug because none of the detection criteria in the `bin/compile` passed.
* The `profile.d` script tried to put the `heroku-metrics-agent.jar` on the agent path even though it didn't exist because the detection passed.
* The app crashed.

The reverse order of buildpacks fixed the problem (because it installed the JDK first) but this is the opposite of what we require for Git based deploys. That's bad.

See:
* https://support.heroku.com/tickets/523050
* https://support.heroku.com/tickets/522311

Let's make sure we merge https://github.com/heroku/heroku-buildpack-metrics/pull/26 first so we can test this.