### PR TITLE
Remove agentmon from Java apps

### DIFF
--- a/.profile.d/heroku-metrics-daemon.sh
+++ b/.profile.d/heroku-metrics-daemon.sh
@@ -5,63 +5,57 @@ if [[ -z "$HEROKU_METRICS_URL" ]] || [[ "${DYNO}" = run\.* ]]; then
     return 0
 fi
 
-export HEROKU_METRICS_PROM_ENDPOINT=${HEROKU_METRICS_PROM_ENDPOINT:-/metrics}
-export HEROKU_METRICS_PROM_PORT=$((PORT + 1))
-
-STARTTIME=$(date +%s)
-BUILD_DIR=/tmp
-
-DOWNLOAD_URL=$(curl --retry 3 -s https://agentmon-releases.s3.amazonaws.com/latest)
-if [ -z "${DOWNLOAD_URL}" ]; then
-    echo "!!!!! Failed to find latest agentmon. Please report this as a bug. Metrics collection will be disabled this run."
-    return 0
-fi
-
-BASENAME=$(basename "${DOWNLOAD_URL}")
-
-curl -L --retry 3 -s -o "${BUILD_DIR}/${BASENAME}" "${DOWNLOAD_URL}"
-
-# Ensure the bin folder exists, if not already.
-mkdir -p "${BUILD_DIR}/bin"
-
-# Extract agentmon release
-tar --warning=no-unknown-keyword -C "${BUILD_DIR}/bin" -zxf "${BUILD_DIR}/${BASENAME}"
-chmod +x "${BUILD_DIR}/bin/agentmon"
-
-ELAPSEDTIME=$(($(date +%s) - STARTTIME))
-echo "agentmon setup took ${ELAPSEDTIME} seconds"
-
-AGENTMON_FLAGS=()
-
 # heroku-metrics-agent.jar is added in bin/compile
-if [[ -f bin/heroku-metrics-agent.jar ]]; then
+if [[ -f ${HOME}/bin/heroku-metrics-agent.jar ]]; then
     if [[ -f build.sbt ]] || # Scala
        [[ -d target/resolution-cache ]]; then # Scala (sbt-heroku)
-        unzip -qq bin/heroku-metrics-agent.jar 'javax/*' -d bin/ext/
-        export JAVA_OPTS="-javaagent:bin/heroku-metrics-agent.jar=cp=/app/bin/ext/ -Xbootclasspath/a:bin/heroku-metrics-agent.jar ${JAVA_OPTS}"
-        AGENTMON_FLAGS+=("-prom-url=http://localhost:${HEROKU_METRICS_PROM_PORT}${HEROKU_METRICS_PROM_ENDPOINT}")
-    elif [[ -f pom.xml ]] || # Maven
-         [[ -f build.gradle ]] || # Gradle
-         [[ -f project.clj ]] || # Clojure
-         [[ -f target/dependency/webapp-runner.jar ]] || # Tomcat
-         [[ -d .jdk ]]; then # heroku/jvm
-        export JAVA_TOOL_OPTIONS="-javaagent:bin/heroku-metrics-agent.jar ${JAVA_TOOL_OPTIONS}"
-        AGENTMON_FLAGS+=("-prom-url=http://localhost:${HEROKU_METRICS_PROM_PORT}${HEROKU_METRICS_PROM_ENDPOINT}")
+        export JAVA_OPTS="-javaagent:${HOME}/bin/heroku-metrics-agent.jar ${JAVA_OPTS}"
+    else
+        export JAVA_TOOL_OPTIONS="-javaagent:${HOME}/bin/heroku-metrics-agent.jar ${JAVA_TOOL_OPTIONS}"
     fi
 else
+    export HEROKU_METRICS_PROM_ENDPOINT=${HEROKU_METRICS_PROM_ENDPOINT:-/metrics}
+    export HEROKU_METRICS_PROM_PORT=$((PORT + 1))
+
+    STARTTIME=$(date +%s)
+    BUILD_DIR=/tmp
+
+    DOWNLOAD_URL=$(curl --retry 3 -s https://agentmon-releases.s3.amazonaws.com/latest)
+    if [ -z "${DOWNLOAD_URL}" ]; then
+        echo "!!!!! Failed to find latest agentmon. Please report this as a bug. Metrics collection will be disabled this run."
+        return 0
+    fi
+
+    BASENAME=$(basename "${DOWNLOAD_URL}")
+
+    curl -L --retry 3 -s -o "${BUILD_DIR}/${BASENAME}" "${DOWNLOAD_URL}"
+
+    # Ensure the bin folder exists, if not already.
+    mkdir -p "${BUILD_DIR}/bin"
+
+    # Extract agentmon release
+    tar --warning=no-unknown-keyword -C "${BUILD_DIR}/bin" -zxf "${BUILD_DIR}/${BASENAME}"
+    chmod +x "${BUILD_DIR}/bin/agentmon"
+
+    ELAPSEDTIME=$(($(date +%s) - STARTTIME))
+    echo "agentmon setup took ${ELAPSEDTIME} seconds"
+
+    AGENTMON_FLAGS=()
+
     AGENTMON_FLAGS+=("-statsd-addr=:${PORT}")
-fi
 
-if [[ "${AGENTMON_DEBUG}" = "true" ]]; then
-    AGENTMON_FLAGS+=("-debug")
-fi
 
-if [[ -x "${BUILD_DIR}/bin/agentmon" ]]; then
-    (while true; do
-        ${BUILD_DIR}/bin/agentmon "${AGENTMON_FLAGS[@]}" "${HEROKU_METRICS_URL}"
-        echo "agentmon completed with status=${?}. Restarting"
-        sleep 1
-    done) &
-else
-    echo "No agentmon executable found. Not starting."
+    if [[ "${AGENTMON_DEBUG}" = "true" ]]; then
+        AGENTMON_FLAGS+=("-debug")
+    fi
+
+    if [[ -x "${BUILD_DIR}/bin/agentmon" ]]; then
+        (while true; do
+            ${BUILD_DIR}/bin/agentmon "${AGENTMON_FLAGS[@]}" "${HEROKU_METRICS_URL}"
+            echo "agentmon completed with status=${?}. Restarting"
+            sleep 1
+        done) &
+    else
+        echo "No agentmon executable found. Not starting."
+    fi
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -27,7 +27,7 @@ if [[ -f "${BUILD_DIR}/pom.xml" ]] || # Maven
     mkdir -p "${BUILD_DIR}/bin/"
     agent_jar="${BUILD_DIR}/bin/heroku-metrics-agent.jar"
     curl --retry 3 -s -o ${agent_jar} \
-      -L ${HEROKU_METRICS_JAR_URL:-"http://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.0/heroku-java-metrics-agent-3.0.jar"}
+      -L ${HEROKU_METRICS_JAR_URL:-"http://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.1/heroku-java-metrics-agent-3.1.jar"}
     if [[ ! -f ${agent_jar} ]]; then
         indent "WARNING: failed to install metrics agent!"
     fi

--- a/bin/compile
+++ b/bin/compile
@@ -12,7 +12,7 @@ BUILD_DIR=$1
 #CACHE_DIR=$2
 #ENV_DIR=$3
 
-arrow "Setting up .profile.d to automatically run agentmon..."
+arrow "Setting up .profile.d to automatically run metrics agent..."
 mkdir -p "${BUILD_DIR}/.profile.d"
 cp .profile.d/heroku-metrics-daemon.sh "${BUILD_DIR}/.profile.d"
 
@@ -25,5 +25,10 @@ if [[ -f "${BUILD_DIR}/pom.xml" ]] || # Maven
    [[ -d "${BUILD_DIR}/.jdk" ]]; then # heroku/jvm
     arrow "Installing Java metrics agent"
     mkdir -p "${BUILD_DIR}/bin/"
-    curl --retry 3 -s -o "${BUILD_DIR}/bin/heroku-metrics-agent.jar" -L https://lang-jvm.s3.amazonaws.com/heroku-metrics-agent-2.0.jar
+    agent_jar="${BUILD_DIR}/bin/heroku-metrics-agent.jar"
+    curl --retry 3 -s -o ${agent_jar} \
+      -L ${HEROKU_METRICS_JAR_URL:-"http://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.0/heroku-java-metrics-agent-3.0.jar"}
+    if [[ ! -f ${agent_jar} ]]; then
+        indent "WARNING: failed to install metrics agent!"
+    fi
 fi


### PR DESCRIPTION
**DO NOT MERGE UNTIL 11/13**

This change updates the buildpack to use verion 3.0 of the heroku-java-metrics-agent. This version re-implements the agentmon logic, and therefore doesn't require the buildpack to install agentmon.