### PR TITLE
Enable metrics agent for web dynos only

### DIFF
--- a/.profile.d/heroku-metrics-daemon.sh
+++ b/.profile.d/heroku-metrics-daemon.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # don't do anything if we don't have a metrics url.
-if [[ -z "$HEROKU_METRICS_URL" ]] || [[ "${DYNO}" = run\.* ]]; then
+if [[ -z "$HEROKU_METRICS_URL" ]] || [[ "${DYNO}" != web\.* ]]; then
     return 0
 fi
 


### PR DESCRIPTION
This fixes a problem where worker dynos do not receive a SIGKILL, and the Java metrics agent causes the process to hang (because the Jetty server never exits).

See: https://support.heroku.com/tickets/525923