### PR TITLE
Upgrade java metrics agent to version 3.3

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -27,7 +27,7 @@ if [[ -f "${BUILD_DIR}/pom.xml" ]] || # Maven
     mkdir -p "${BUILD_DIR}/bin/"
     agent_jar="${BUILD_DIR}/bin/heroku-metrics-agent.jar"
     curl --retry 3 -s -o ${agent_jar} \
-      -L ${HEROKU_METRICS_JAR_URL:-"http://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.1/heroku-java-metrics-agent-3.1.jar"}
+      -L ${HEROKU_METRICS_JAR_URL:-"http://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.3/heroku-java-metrics-agent-3.3.jar"}
     if [[ ! -f ${agent_jar} ]]; then
         indent "WARNING: failed to install metrics agent!"
     fi


### PR DESCRIPTION
This fixes a bug in the JVM GC metrics in which net GC time was shown instead of per interval.