### PR TITLE
Use returns in a func in profile.d instead of exits

### DIFF
--- a/.profile.d/heroku-metrics-daemon.sh
+++ b/.profile.d/heroku-metrics-daemon.sh
@@ -1,46 +1,49 @@
 #!/bin/bash
 
-# don't do anything if we don't have a metrics url.
-if [[ -z "$HEROKU_METRICS_URL" ]] || [[ "${DYNO}" = run\.* ]]; then
-    exit 0
-fi
+setup_metrics() {
+    # don't do anything if we don't have a metrics url.
+    if [[ -z "$HEROKU_METRICS_URL" ]] || [[ "${DYNO}" = run\.* ]]; then
+        return 0
+    fi
 
+    STARTTIME=$(date +%s)
+    BUILD_DIR=/tmp
 
-STARTTIME=$(date +%s)
-BUILD_DIR=/tmp
+    DOWNLOAD_URL=$(curl --retry 3 -s https://agentmon-releases.s3.amazonaws.com/latest)
+    if [ -z "${DOWNLOAD_URL}" ]; then
+        echo "!!!!! Failed to find latest agentmon. Please report this as a bug. Metrics collection will be disabled this run."
+        return 1
+    fi
 
-DOWNLOAD_URL=$(curl --retry 3 -s https://agentmon-releases.s3.amazonaws.com/latest)
-if [ -z "${DOWNLOAD_URL}" ]; then
-    echo "!!!!! Failed to find latest agentmon. Please report this as a bug. Metrics collection will be disabled this run."
-    exit 0
-fi
+    BASENAME=$(basename "${DOWNLOAD_URL}")
 
-BASENAME=$(basename "${DOWNLOAD_URL}")
+    curl -L --retry 3 -s -o "${BUILD_DIR}/${BASENAME}" "${DOWNLOAD_URL}"
 
-curl -L --retry 3 -s -o "${BUILD_DIR}/${BASENAME}" "${DOWNLOAD_URL}"
+    # Ensure the bin folder exists, if not already.
+    mkdir -p "${BUILD_DIR}/bin"
 
-# Ensure the bin folder exists, if not already.
-mkdir -p "${BUILD_DIR}/bin"
+    # Extract agentmon release
+    tar --warning=no-unknown-keyword -C "${BUILD_DIR}/bin" -zxf "${BUILD_DIR}/${BASENAME}"
+    chmod +x "${BUILD_DIR}/bin/agentmon"
 
-# Extract agentmon release
-tar --warning=no-unknown-keyword -C "${BUILD_DIR}/bin" -zxf "${BUILD_DIR}/${BASENAME}"
-chmod +x "${BUILD_DIR}/bin/agentmon"
+    ELAPSEDTIME=$(($(date +%s) - STARTTIME))
+    echo "agentmon setup took ${ELAPSEDTIME} seconds"
 
-ELAPSEDTIME=$(($(date +%s) - STARTTIME))
-echo "agentmon setup took ${ELAPSEDTIME} seconds"
+    AGENTMON_FLAGS=("-statsd-addr=:${PORT}")
 
-AGENTMON_FLAGS=("-statsd-addr=:${PORT}")
+    if [[ "${AGENTMON_DEBUG}" = "true" ]]; then
+        AGENTMON_FLAGS+=("-debug")
+    fi
 
-if [[ "${AGENTMON_DEBUG}" = "true" ]]; then
-    AGENTMON_FLAGS+=("-debug")
-fi
+    if [[ -x "${BUILD_DIR}/bin/agentmon" ]]; then
+        (while true; do
+            ${BUILD_DIR}/bin/agentmon "${AGENTMON_FLAGS[@]}" "${HEROKU_METRICS_URL}"
+            echo "agentmon completed with status=${?}. Restarting"
+            sleep 1
+        done) &
+    else
+        echo "No agentmon executable found. Not starting."
+    fi
+}
 
-if [[ -x "${BUILD_DIR}/bin/agentmon" ]]; then
-    (while true; do
-        ${BUILD_DIR}/bin/agentmon "${AGENTMON_FLAGS[@]}" "${HEROKU_METRICS_URL}"
-        echo "agentmon completed with status=${?}. Restarting"
-        sleep 1
-    done) &
-else
-    echo "No agentmon executable found. Not starting."
-fi
+setup_metrics


### PR DESCRIPTION
It would seem these `exit` statements are breaking some apps. I suspect the use of pgbouncer buildpack is related. See https://support.heroku.com/tickets/587286