### PR TITLE
Update Ruby dependencies and fix Dependabot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem 'heroku_hatchet', '3.0.4'
+gem 'heroku_hatchet'
 gem 'rspec-retry'
 gem 'rspec-expectations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,73 +1,52 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.2)
-      base64
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
-    base64 (0.2.0)
-    bigdecimal (3.1.5)
-    concurrent-ruby (1.2.2)
-    connection_pool (2.4.1)
-    diff-lcs (1.2.5)
-    drb (2.2.0)
-      ruby2_keywords
+    base64 (0.3.0)
+    diff-lcs (1.6.2)
     erubis (2.7.0)
-    excon (0.76.0)
-    heroics (0.0.24)
+    excon (1.2.8)
+      logger
+    heroics (0.1.3)
+      base64
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
-    heroku_hatchet (3.0.4)
-      excon (~> 0)
-      minitest-retry (~> 0.1.9)
-      platform-api (~> 2)
-      repl_runner (~> 0.0.3)
+      webrick
+    heroku_hatchet (8.0.6)
+      excon (< 2)
+      platform-api (~> 3)
       rrrretry (~> 1)
-      thor (~> 0)
+      thor (~> 1)
       threaded (~> 0)
-    i18n (1.14.1)
-      concurrent-ruby (~> 1.0)
-    minitest (5.21.1)
-    minitest-retry (0.1.9)
-      minitest (>= 5.0)
-    moneta (0.8.1)
-    multi_json (1.12.2)
-    mutex_m (0.2.0)
-    platform-api (2.1.0)
-      heroics (~> 0.0.23)
-      moneta (~> 0.8.1)
-    repl_runner (0.0.3)
-      activesupport
+    logger (1.7.0)
+    moneta (1.0.0)
+    multi_json (1.17.0)
+    platform-api (3.8.0)
+      heroics (~> 0.1.1)
+      moneta (~> 1.0.0)
+      rate_throttle_client (~> 0.1.0)
+    rate_throttle_client (0.1.2)
     rrrretry (1.0.0)
-    rspec-core (3.4.1)
-      rspec-support (~> 3.4.0)
-    rspec-expectations (3.4.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-retry (0.4.5)
-      rspec-core
-    rspec-support (3.4.1)
-    ruby2_keywords (0.0.5)
-    thor (0.20.0)
+      rspec-support (~> 3.13.0)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
+    rspec-support (3.13.4)
+    thor (1.4.0)
     threaded (0.0.4)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
+    webrick (1.9.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  heroku_hatchet (= 3.0.4)
+  heroku_hatchet
   rspec-expectations
   rspec-retry
 
 BUNDLED WITH
-   1.15.4
+   2.7.1


### PR DESCRIPTION
Dependabot hadn't been opening PRs since it was erroring with:

```
Dependabot does not support your bundler version

Dependabot detected the following bundler requirement for your project: '1'.

Currently, the following bundler versions are supported in Dependabot: v2.*.
```

I've refreshed the lockfile to both update to newer Bundler and also update all deps, which resolves the currently open security alert:
https://github.com/heroku/heroku-buildpack-metrics/security/dependabot/8

GUS-W-19165572.