### PR TITLE
Skip install when barnes 1.0.0+ detected

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,18 +4,10 @@ set -euo pipefail
 BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)
 source "${BUILDPACK_DIR}/lib/output.sh"
 
-arrow() {
-  echo '----->' "$@"
-}
-
-indent() {
-  sed -u 's/^/       /'
-}
-
 BUILD_DIR=$1
 #CACHE_DIR=$2
 #ENV_DIR=$3
 
-arrow "Setting up .profile.d to automatically run metrics agent..."
+output::step "Setting up .profile.d to automatically run metrics agent..."
 mkdir -p "${BUILD_DIR}/.profile.d"
 cp .profile.d/heroku-metrics-daemon.sh "${BUILD_DIR}/.profile.d"

--- a/bin/compile
+++ b/bin/compile
@@ -9,6 +9,106 @@ BUILD_DIR=$1
 #CACHE_DIR=$2
 #ENV_DIR=$3
 
-output::step "Setting up .profile.d to automatically run metrics agent..."
-mkdir -p "${BUILD_DIR}/.profile.d"
-cp .profile.d/heroku-metrics-daemon.sh "${BUILD_DIR}/.profile.d"
+if [[ -f "${BUILD_DIR}/Gemfile.lock" ]]; then
+	output::indent <<< "Detected \`Gemfile.lock\`"
+	BARNES_VERSION=$(barnes_version "${BUILD_DIR}/Gemfile.lock" || true)
+	if [[ -n "$BARNES_VERSION" ]]; then
+		output::indent <<< "Detected \`barnes\` gem version \`${BARNES_VERSION}\`"
+		if version_gte "$BARNES_VERSION" "1.0.0"; then
+			STATUS="barnes-good"
+		else
+			STATUS="barnes-needs-upgrade"
+		fi
+	else
+		output::indent <<< "Missing \`barnes\` gem from \`Gemfile.lock\`"
+		STATUS="missing-barnes"
+	fi
+else
+	output::indent <<< "Missing \`Gemfile.lock\`"
+	STATUS="missing-gemfile-lock"
+fi
+
+case "$STATUS" in
+	barnes-good)
+		output::indent <<< "Metrics daemon not needed, skipping install."
+		output::warning <<-EOF
+			Warning: Please remove this buildpack
+
+			The \`heroku/metrics\` buildpack is no longer needed. Please remove it
+			from your application by running:
+
+				$ buildpacks:remove heroku/metrics
+		EOF
+		;;
+	barnes-needs-upgrade)
+		output::warning <<-EOF
+			Warning: Upgrade \`barnes\` gem
+
+			The \`heroku/metrics\` buildpack is used exclusively for the Heroku Ruby
+			Language Metrics (beta). The functionality of this buildpack is being
+			moved into the \`barnes\` gem and future releases gate behavior based on the
+			version of this gem in the \`Gemfile.lock\`.
+
+			Upgrade your \`barnes\` version and check the results into git:
+
+				$ bundle update barnes
+				$ git add Gemfile.lock
+				$ git commit -m "Upgrade barnes 1.0.0+"
+
+			Remove this buildpack, and then re-deploy:
+
+				$ buildpacks:remove heroku/metrics
+				$ git push heroku main
+		EOF
+		;;
+	missing-barnes|missing-gemfile-lock)
+		output::warning <<-EOF
+			Warning: Cannot determine barnes version
+
+			The \`heroku/metrics\` buildpack is used exclusively for the Heroku Ruby
+			Language Metrics (beta). The functionality of this buildpack is being
+			moved into the \`barnes\` gem and future releases gate behavior based on the
+			version of this gem in the \`Gemfile.lock\`.
+
+			To remove this warning ensure there is a \`Gemfile.lock\` in the root of your
+			application and that it contains \`gem 'barnes'\`:
+
+			     \$ ls -la
+			$(ls -la "$BUILD_DIR" | sed 's/^/     /')
+
+			If your application does not rely on this buildpack, please remove it by
+			running:
+
+				$ buildpacks:remove heroku/metrics
+
+			https://github.com/heroku/heroku-buildpack-metrics/issues
+		EOF
+		;;
+	*)
+		output::warning <<-EOF
+			Warning: Internal error
+
+			The \`heroku/metrics\` buildpack encountered an unexpected state:
+
+				STATUS=${STATUS}
+
+			Please search or file an issue on GitHub. Please include
+			your build logs and the contents of the root of your application:
+
+			https://github.com/heroku/heroku-buildpack-metrics/issues
+		EOF
+		;;
+esac
+
+case "$STATUS" in
+	barnes-good)
+		# Barnes doesn't need `heroku/metrics`, install nothing
+		;;
+	*)
+		# Install the metrics agent for all statuses except barnes-good,
+		# which has metrics support built in.
+		output::step "Setting up .profile.d to automatically run metrics agent..."
+		mkdir -p "${BUILD_DIR}/.profile.d"
+		cp .profile.d/heroku-metrics-daemon.sh "${BUILD_DIR}/.profile.d"
+		;;
+esac

--- a/bin/compile
+++ b/bin/compile
@@ -3,6 +3,7 @@ set -euo pipefail
 
 BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)
 source "${BUILDPACK_DIR}/lib/output.sh"
+source "${BUILDPACK_DIR}/lib/utils.sh"
 
 BUILD_DIR=$1
 #CACHE_DIR=$2

--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)
+source "${BUILDPACK_DIR}/lib/output.sh"
+
 arrow() {
   echo '----->' "$@"
 }

--- a/bin/compile
+++ b/bin/compile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)

--- a/bin/compile
+++ b/bin/compile
@@ -37,7 +37,7 @@ case "$STATUS" in
 			The \`heroku/metrics\` buildpack is no longer needed. Please remove it
 			from your application by running:
 
-				$ buildpacks:remove heroku/metrics
+				$ heroku buildpacks:remove heroku/metrics
 		EOF
 		;;
 	barnes-needs-upgrade)
@@ -57,7 +57,7 @@ case "$STATUS" in
 
 			Remove this buildpack, and then re-deploy:
 
-				$ buildpacks:remove heroku/metrics
+				$ heroku buildpacks:remove heroku/metrics
 				$ git push heroku main
 		EOF
 		;;
@@ -79,7 +79,7 @@ case "$STATUS" in
 			If your application does not rely on this buildpack, please remove it by
 			running:
 
-				$ buildpacks:remove heroku/metrics
+				$ heroku buildpacks:remove heroku/metrics
 
 			https://github.com/heroku/heroku-buildpack-metrics/issues
 		EOF

--- a/bin/compile
+++ b/bin/compile
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)
 source "${BUILDPACK_DIR}/lib/output.sh"

--- a/bin/detect
+++ b/bin/detect
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "HerokuRuntimeMetrics"

--- a/bin/release
+++ b/bin/release
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "--- {}"

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# This is technically redundant, since all consumers of this lib will have enabled these,
+# however, it helps Shellcheck realise the options under which these functions will run.
+set -euo pipefail
+
+ANSI_BLUE=$'\e[1;34m'
+ANSI_RED=$'\e[1;31m'
+ANSI_YELLOW=$'\e[1;33m'
+ANSI_RESET=$'\e[0m'
+
+# Output a single line step message to stdout.
+#
+# Usage:
+# ```
+# output::step "Installing Python ..."
+# ```
+function output::step() {
+	echo "-----> ${1}"
+}
+
+# Indent passed stdout. Typically used to indent command output within a step.
+#
+# Usage:
+# ```
+# pip install ... |& output::indent
+# ```
+function output::indent() {
+	sed --unbuffered "s/^/       /"
+}
+
+# Output a styled multi-line notice message to stderr.
+#
+# Usage:
+# ```
+# output::notice <<-EOF
+# 	Note: The note summary.
+#
+# 	Detailed description.
+# EOF
+# ```
+function output::notice() {
+	echo >&2
+	sed --expression "s/^/${ANSI_BLUE} !     /" --expression "s/$/${ANSI_RESET}/" >&2
+	echo >&2
+}
+
+# Output a styled multi-line warning message to stderr.
+#
+# Usage:
+# ```
+# output::warning <<-EOF
+# 	Warning: The warning summary.
+#
+# 	Detailed description.
+# EOF
+# ```
+function output::warning() {
+	echo >&2
+	sed --expression "s/^/${ANSI_YELLOW} !     /" --expression "s/$/${ANSI_RESET}/" >&2
+	echo >&2
+}
+
+# Output a styled multi-line error message to stderr.
+#
+# Usage:
+# ```
+# output::error <<-EOF
+# 	Error: The error summary.
+#
+# 	Detailed description.
+# EOF
+# ```
+function output::error() {
+	echo >&2
+	sed --expression "s/^/${ANSI_RED} !     /" --expression "s/$/${ANSI_RESET}/" >&2
+	echo >&2
+}

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# This is technically redundant, since all consumers of this lib will have enabled these,
+# however, it helps Shellcheck realise the options under which these functions will run.
+set -euo pipefail
+
+# Extracts the barnes gem version from a Gemfile.lock
+#
+# ```
+# barnes_version "Gemfile.lock"
+# # => "0.1.0"
+# ```
+barnes_version() {
+  local gemfile_lock="$1"
+  grep -E '^[[:space:]]+barnes[[:space:]]+\(' "$gemfile_lock" | sed -E 's/.*barnes \(([^)]+)\).*/\1/'
+}

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -14,3 +14,14 @@ barnes_version() {
   local gemfile_lock="$1"
   grep -E '^[[:space:]]+barnes[[:space:]]+\(' "$gemfile_lock" | sed -E 's/.*barnes \(([^)]+)\).*/\1/'
 }
+
+# Determines which string is greater or equal
+#
+# ```
+# version_gte "1.0.0" "1.0.0"; echo $? # => 0
+# version_gte "1.0.1" "1.0.0"; echo $? # => 0
+# version_gte "1.0.0" "1.0.1"; echo $? # => 1
+# ```
+version_gte() {
+  [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+}


### PR DESCRIPTION
This buildpack works by downloading a daemon to convert StatsD to something Heroku can ingest. It is used only by Ruby customers https://devcenter.heroku.com/articles/language-runtime-metrics-ruby. Other languages that support the metrics beta write directly to the metrics endpoint and bypass StatsD. 

As of https://github.com/heroku/barnes/pull/50 and the barnes 1.0.0 release, Ruby customers no longer need it either. This PR skips installing the metrics agent for customers using barnes 1.0.0+, while encouraging everyone else to upgrade.

The ultimate goal is to sunset this buildpack and archive this git repo.

GUS-W-22249430